### PR TITLE
Bug fix

### DIFF
--- a/src/main/java/com/group6/wishshare/data/repository/UserRepository.java
+++ b/src/main/java/com/group6/wishshare/data/repository/UserRepository.java
@@ -30,7 +30,7 @@ public class UserRepository {
 
       ResultSet rs = ps.getGeneratedKeys();
       if (rs.next()) {
-        return rs.getInt("user_id");
+        return rs.getInt(1);
       }
 
       return 0;

--- a/src/main/java/com/group6/wishshare/data/repository/WishlistRepository.java
+++ b/src/main/java/com/group6/wishshare/data/repository/WishlistRepository.java
@@ -35,7 +35,7 @@ public class WishlistRepository {
         return new Wishlist.WishListBuilder()
             .wishList(new ArrayList<>())
             .name(name)
-            .id(gk.getInt("wishlist_id"))
+            .id(gk.getInt(1))
             .token(token)
             .user(user)
             .build();


### PR DESCRIPTION
Cant use column name on GeneratedKeys.

the column name  would be "GENERATED_KEY" and not user_id

Reversed change from previous PR back to use columnIndex 1

What kind of change does this PR introduce?

- [x] `bug-fix`
- [ ] `new-feature`
- [ ] `enhancement`